### PR TITLE
ImageModule Swift fix

### DIFF
--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -233,7 +233,7 @@ public final class ImageModule: Module {
 
   func generatePlaceholder(
     source: Either<Image, URL>,
-    generator: @escaping (UIImage) -> Void,
+    generator: @escaping (UIImage) -> Void
   ) {
     if let image: Image = source.get() {
       generator(image.ref)


### PR DESCRIPTION
# Why
This PR removes the comma that caused compilation errors for the iOS platform in bare-expo

<img width="492" height="189" alt="image" src="https://github.com/user-attachments/assets/4658146a-cc98-4804-928a-6394ab292e71" />

# How
I deleted the comma from `ImageModule.swift` in function `generatePlaceholder`

# Test Plan
I tested it on iOS

# Checklist
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
