### PR TITLE
WebSupport is added

### DIFF
--- a/packages/expo-blob/build/BlobModule.web.d.ts
+++ b/packages/expo-blob/build/BlobModule.web.d.ts
@@ -1,0 +1,5 @@
+export declare const ExpoBlob: {
+    new (blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
+    prototype: Blob;
+};
+//# sourceMappingURL=BlobModule.web.d.ts.map

--- a/packages/expo-blob/build/BlobModule.web.d.ts.map
+++ b/packages/expo-blob/build/BlobModule.web.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"BlobModule.web.d.ts","sourceRoot":"","sources":["../src/BlobModule.web.ts"],"names":[],"mappings":"AAAA,eAAO,MAAM,QAAQ;;;CAAO,CAAC"}

--- a/packages/expo-blob/build/BlobModule.web.js
+++ b/packages/expo-blob/build/BlobModule.web.js
@@ -1,0 +1,2 @@
+export const ExpoBlob = Blob;
+//# sourceMappingURL=BlobModule.web.js.map

--- a/packages/expo-blob/build/BlobModule.web.js.map
+++ b/packages/expo-blob/build/BlobModule.web.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"BlobModule.web.js","sourceRoot":"","sources":["../src/BlobModule.web.ts"],"names":[],"mappings":"AAAA,MAAM,CAAC,MAAM,QAAQ,GAAG,IAAI,CAAC","sourcesContent":["export const ExpoBlob = Blob;\n"]}

--- a/packages/expo-blob/src/BlobModule.web.ts
+++ b/packages/expo-blob/src/BlobModule.web.ts
@@ -1,0 +1,1 @@
+export const ExpoBlob = Blob;


### PR DESCRIPTION
# Why
Adding support for web.

# How

# Test Plan

# Checklist
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
