### PR TITLE
Swift improvment

### DIFF
--- a/packages/expo-blob/ios/Blob.swift
+++ b/packages/expo-blob/ios/Blob.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ExpoModulesCore
 
-let MAX_CHUNK_BYTE_SIZE = 16384
+let MAX_CHUNK_BYTE_SIZE = 16_384
 
 public class Blob: SharedObject {
   var blobParts: [BlobPart]
@@ -23,9 +23,8 @@ public class Blob: SharedObject {
     guard let data = str.data(using: .utf8) else { return [] }
     if data.count <= MAX_CHUNK_BYTE_SIZE / 4 {
       return [.string(str)]
-    } else {
-      return chunkData(data)
     }
+  return chunkData(data)
   }
 
   init(blobParts: [BlobPart]?, options: BlobOptions?) {

--- a/packages/expo-blob/ios/Blob.swift
+++ b/packages/expo-blob/ios/Blob.swift
@@ -1,12 +1,51 @@
 import Foundation
 import ExpoModulesCore
 
+let kBlobChunkSize = 8192 * 2
+
 public class Blob: SharedObject {
   var blobParts: [BlobPart]
   var options: BlobOptions
 
+  static func chunkData(_ data: Data) -> [BlobPart] {
+    var chunks: [BlobPart] = []
+    var offset = 0
+    while offset < data.count {
+      let end = min(offset + kBlobChunkSize, data.count)
+      let chunk = data.subdata(in: offset..<end)
+      chunks.append(.data(chunk))
+      offset = end
+    }
+    return chunks
+  }
+
+  static func chunkString(_ str: String) -> [BlobPart] {
+    var parts: [BlobPart] = []
+    var current = str.startIndex
+    while current < str.endIndex {
+      let next = str.index(current, offsetBy: kBlobChunkSize, limitedBy: str.endIndex) ?? str.endIndex
+      let chunk = String(str[current..<next])
+      if let data = chunk.data(using: .utf8) {
+        parts.append(.data(data))
+      }
+      current = next
+    }
+    return parts
+  }
+
   init(blobParts: [BlobPart]?, options: BlobOptions?) {
-    self.blobParts = blobParts ?? []
+    var chunkedParts: [BlobPart] = []
+    for part in blobParts ?? [] {
+      switch part {
+        case .data(let data):
+          chunkedParts.append(contentsOf: Blob.chunkData(data))
+        case .blob(let blob):
+          chunkedParts.append(.blob(blob))
+        case .string(let str):
+          chunkedParts.append(contentsOf: Blob.chunkString(str))
+      }
+    }
+    self.blobParts = chunkedParts
     self.options = options ?? BlobOptions()
   }
 
@@ -21,66 +60,68 @@ public class Blob: SharedObject {
   func slice(start: Int, end: Int, contentType: String) -> Blob {
     let span = max(end - start, 0)
     let typeString = contentType
-
     if span == 0 {
       return Blob(blobParts: [], options: BlobOptions(type: typeString, endings: self.options.endings))
     }
-
     var dataSlice: [BlobPart] = []
     var currentPos = 0
     var remaining = span
-
     for part in blobParts {
       let partSize = part.size()
-
       if currentPos + partSize <= start {
         currentPos += partSize
         continue
       }
-
       if remaining <= 0 {
         break
       }
-
       let partStart = max(0, start - currentPos)
       let partEnd = min(partSize, partStart + remaining)
       let length = partEnd - partStart
-
       if length <= 0 {
         currentPos += partSize
         continue
       }
-
       if partStart == 0 && partEnd == partSize {
         dataSlice.append(part)
       } else {
         switch part {
-          case .string(let str):
-            let utf8 = Array(str.utf8)
-            let subUtf8 = Array(utf8[partStart..<partEnd])
-            if let subStr = String(bytes: subUtf8, encoding: .utf8) {
-              dataSlice.append(.string(subStr))
-            }
           case .data(let data):
             let subData = data.subdata(in: partStart..<partEnd)
             dataSlice.append(.data(subData))
           case .blob(let blob):
             let subBlob = blob.slice(start: partStart, end: partEnd, contentType: blob.type)
             dataSlice.append(.blob(subBlob))
+          case .string:
+            break
         }
       }
-
       currentPos += partSize
       remaining -= length
     }
-
     return Blob(blobParts: dataSlice, options: BlobOptions(type: typeString, endings: self.options.endings))
   }
 
-  func text() -> String {
-    return blobParts.reduce("") { $0 + $1.text() }
+  func text() async -> String {
+    var allBytes: [UInt8] = []
+    for part in blobParts {
+      switch part {
+        case .data(let data):
+          allBytes.append(contentsOf: [UInt8](data))
+        case .blob(let blob):
+          allBytes.append(contentsOf: await blob.bytes())
+        case .string:
+          break
+      }
+    }
+    let data = Data(allBytes)
+    if let str = String(data: data, encoding: .utf8) {
+      return str
+    } else {
+      return String(repeating: "\u{FFFD}", count: data.count)
+    }
   }
-
+  
   func bytes() async -> [UInt8] {
     var result: [UInt8] = []
     for part in blobParts {

--- a/packages/expo-blob/ios/Blob.swift
+++ b/packages/expo-blob/ios/Blob.swift
@@ -24,7 +24,7 @@ public class Blob: SharedObject {
     if data.count <= MAX_CHUNK_BYTE_SIZE / 4 {
       return [.string(str)]
     }
-  return chunkData(data)
+    return chunkData(data)
   }
 
   init(blobParts: [BlobPart]?, options: BlobOptions?) {

--- a/packages/expo-blob/ios/BlobPart.swift
+++ b/packages/expo-blob/ios/BlobPart.swift
@@ -7,17 +7,6 @@ enum BlobPart {
 }
 
 extension BlobPart {
-  func text() async -> String {
-    switch self {
-      case .string(let str):
-        return str
-      case .data(let data):
-        return String(decoding: data, as: UTF8.self)
-      case .blob(let blob):
-        return await blob.text()
-    }
-  }
-
   func size() -> Int {
     switch self {
     case .string(let str):

--- a/packages/expo-blob/ios/BlobPart.swift
+++ b/packages/expo-blob/ios/BlobPart.swift
@@ -7,14 +7,14 @@ enum BlobPart {
 }
 
 extension BlobPart {
-  func text() -> String {
+  func text() async -> String {
     switch self {
       case .string(let str):
         return str
       case .data(let data):
         return String(decoding: data, as: UTF8.self)
       case .blob(let blob):
-        return blob.text()
+        return await blob.text()
     }
   }
 

--- a/packages/expo-blob/ios/ExpoBlob.swift
+++ b/packages/expo-blob/ios/ExpoBlob.swift
@@ -44,7 +44,7 @@ public class ExpoBlob: Module {
         return blob.slice(start: relativeStart, end: relativeEnd, contentType: contentType ?? "")
       }
 
-      AsyncFunction("text") { (blob: Blob) in
+      AsyncFunction("text") { (blob: Blob) async -> String in
         await blob.text()
       }
 

--- a/packages/expo-blob/ios/ExpoBlob.swift
+++ b/packages/expo-blob/ios/ExpoBlob.swift
@@ -45,7 +45,7 @@ public class ExpoBlob: Module {
       }
 
       AsyncFunction("text") { (blob: Blob) in
-        blob.text()
+        await blob.text()
       }
 
       AsyncFunction("bytes") { (blob: Blob) async -> Data in


### PR DESCRIPTION
# Why
Improve the Blob implementation in Swift by dividing large data into smaller chunks. 
The size of these chunks is fixed. This way, when calling the slice method, with large data we simply pass the ref instead of copying the objects.

# How

# Test Plan

# Checklist
- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

<img width="402" height="796" alt="Screenshot 2025-07-25 at 17 00 36" src="https://github.com/user-attachments/assets/ffc394eb-dbe3-45b8-b553-028d92124023" />


